### PR TITLE
#9: amend code to skip battery declaration in batteryless systems

### DIFF
--- a/homeassistant.py
+++ b/homeassistant.py
@@ -5,7 +5,6 @@ import pwrcell
 import sunspec2.mdef as mdef
 import sunspec2.modbus.client as ss2_client
 import time
-import pdb
 
 
 class TimeMovingAvg():

--- a/homeassistant.py
+++ b/homeassistant.py
@@ -5,6 +5,7 @@ import pwrcell
 import sunspec2.mdef as mdef
 import sunspec2.modbus.client as ss2_client
 import time
+import pdb
 
 
 class TimeMovingAvg():
@@ -95,48 +96,49 @@ class PwrCellHA():
         device_id='pwrcell_inverter',
         sensor_id='inverter_state')
 
-    self.__define_sensor(
-        self.__pwrcell.battery.battery[0].W,
-        device_id='battery',
-        sensor_id='watts',
-        round_digits=1,
-        moving_average=True,
-        negate=True)
-    self.__define_sensor(
-        self.__pwrcell.battery.battery[0].SoC,
-        device_id='battery',
-        sensor_id='state_of_charge',
-        round_digits=1)
-    self.__define_number(
-        self.__pwrcell.battery.battery[0].SoCMax,
-        device_id='battery',
-        sensor_id='state_of_charge_max')
-    self.__define_number(
-        self.__pwrcell.battery.battery[0].SoCMin,
-        device_id='battery',
-        sensor_id='state_of_charge_min')
-    self.__define_number(
-        self.__pwrcell.battery.battery[0].SoCRsvMax,
-        device_id='battery',
-        sensor_id='state_of_charge_reserve_max')
-    self.__define_number(
-        self.__pwrcell.battery.battery[0].SoCRsvMin,
-        device_id='battery',
-        sensor_id='state_of_charge_reserve_min')
-    self.__define_sensor(
-        self.__pwrcell.battery.battery_status[0].WhIn,
-        device_id='battery',
-        sensor_id='in_watt_hours',
-        state_class='total_increasing')
-    self.__define_sensor(
-        self.__pwrcell.battery.battery_status[0].WhOut,
-        device_id='battery',
-        sensor_id='out_watt_hours',
-        state_class='total_increasing')
-    self.__define_sensor(
-        self.__pwrcell.battery.REbus_status[0].St,
-        device_id='battery',
-        sensor_id='battery_state')
+    if hasattr(self.__pwrcell,'battery'):
+        self.__define_sensor(
+            self.__pwrcell.battery.battery[0].W,
+            device_id='battery',
+            sensor_id='watts',
+            round_digits=1,
+            moving_average=True,
+            negate=True)
+        self.__define_sensor(
+            self.__pwrcell.battery.battery[0].SoC,
+            device_id='battery',
+            sensor_id='state_of_charge',
+            round_digits=1)
+        self.__define_number(
+            self.__pwrcell.battery.battery[0].SoCMax,
+            device_id='battery',
+            sensor_id='state_of_charge_max')
+        self.__define_number(
+            self.__pwrcell.battery.battery[0].SoCMin,
+            device_id='battery',
+            sensor_id='state_of_charge_min')
+        self.__define_number(
+            self.__pwrcell.battery.battery[0].SoCRsvMax,
+            device_id='battery',
+            sensor_id='state_of_charge_reserve_max')
+        self.__define_number(
+            self.__pwrcell.battery.battery[0].SoCRsvMin,
+            device_id='battery',
+            sensor_id='state_of_charge_reserve_min')
+        self.__define_sensor(
+            self.__pwrcell.battery.battery_status[0].WhIn,
+            device_id='battery',
+            sensor_id='in_watt_hours',
+            state_class='total_increasing')
+        self.__define_sensor(
+            self.__pwrcell.battery.battery_status[0].WhOut,
+            device_id='battery',
+            sensor_id='out_watt_hours',
+            state_class='total_increasing')
+        self.__define_sensor(
+            self.__pwrcell.battery.REbus_status[0].St,
+            device_id='battery',
+            sensor_id='battery_state')
 
     for pv_link_id, pv_link in self.__pwrcell.pv_links.items():
       device_id = 'pv_link_{}'.format(pv_link_id)


### PR DESCRIPTION
This PR wraps the battery initialization code in the homeassistant mqtt logic such that if the inverter object does not contain a battery attribute, the battery attribute reporters are skipped.

Offered as a suggested fix to #9 