### PR TITLE
add pvlink volts/amps to output

### DIFF
--- a/homeassistant.py
+++ b/homeassistant.py
@@ -154,6 +154,16 @@ class PwrCellHA():
           sensor_id='watt_hours',
           device_name_suffix=" {}".format(pv_link_id))
       self.__define_sensor(
+          pv_link.pvlink_status[0].Vin,
+          device_id=device_id,
+          sensor_id='input_voltage',
+          device_name_suffix=" {}".format(pv_link_id))
+      self.__define_sensor(
+          pv_link.pvlink_status[0].Iin,
+          device_id=device_id,
+          sensor_id='input_current',
+          device_name_suffix=" {}".format(pv_link_id))
+      self.__define_sensor(
           pv_link.REbus_status[0].St,
           device_id=device_id,
           sensor_id='pvlink_state')
@@ -302,6 +312,12 @@ class PwrCellHA():
         return 'energy'
       if p_units in ['%WHRtg']:
         return 'battery'
+      if p_units is None:
+          p_name = point.pdef.get(mdef.NAME)
+          if p_name in ['Vin']:
+              return 'voltage'
+          if p_name in ['Iin']:
+              return 'current'
       else:
         raise ValueError("SC UNKNOWN Units(%s) for Type(%s)\n\t%s" %
                          (p_units, point.pdef[mdef.TYPE], point.pdef))
@@ -313,6 +329,12 @@ class PwrCellHA():
     p_units = point.pdef.get(mdef.UNITS)
     if p_units in ['%WHRtg']:
       return '%'
+    if p_units is None:
+        p_name = point.pdef.get(mdef.NAME)
+        if p_name in ['Vin']:
+            return 'V'
+        if p_name in ['Iin']:
+            return 'A'
     else:
       return p_units
 

--- a/pwrcell.py
+++ b/pwrcell.py
@@ -115,7 +115,7 @@ class GeneracPwrCell():
     for t in range(tries):
       try:
         # Don't read all model data (it is slow)
-        device.scan(connect=False, full_model_read=False)
+        device.scan(connect=False, full_model_read=True)
         device.common[0].read()
         logging.info("Scanned %s as %s %s - %s",
                      device.name,


### PR DESCRIPTION
This PR implements `Vin` and `Iin` readout from the pvlink units, enabling one to ascertain if the actual panels are producing the expected voltage/amperage.  This is relevant because the inverter will dynamically disable strings in ExportOverride mode to reduce possibility of exporting energy, but the voltage will still read properly off the pvlink (thus validating that the panels are inherently 'ready', just disabled.)

I know you said "don't do a full scan!" in the comment right above me doing a full scan -- if there's a better place to specify 'models we want to iterate' let me know and I'll amend this PR to just bring in 64211/64251.

(cc @oriolism)